### PR TITLE
feat: add universal language parser support

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +190,27 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    from src.parser.base import ParseResult
+    parse_result = ParseResult()
+    for res in results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+        if res.language != "unknown":
+            if parse_result.language == "unknown":
+                parse_result.language = res.language
+            elif parse_result.language != res.language and res.language not in parse_result.language:
+                parse_result.language += f", {res.language}"
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -430,6 +448,10 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "universal": [
+        ".js", ".ts", ".java", ".cpp", ".c", ".go", ".rs",
+        ".rb", ".php", ".cs", ".swift", ".kt", ".scala", ".m", ".h"
+    ],
 }
 
 

--- a/src/generator/templates.py
+++ b/src/generator/templates.py
@@ -306,7 +306,7 @@ def render_function(func: FunctionInfo) -> str:
     lines = [
         "#### `{}`".format(func.name),
         "",
-        "```python",
+        "```",
     ]
 
     # Decorators
@@ -314,7 +314,7 @@ def render_function(func: FunctionInfo) -> str:
         for dec in func.decorators:
             lines.append("@{}".format(dec))
 
-    lines.append("def {}{}{}".format(func.name, sig, ret))
+    lines.append("{}{}{}".format(func.name, sig, ret))
     lines.append("```")
     lines.append("")
 
@@ -379,7 +379,7 @@ def render_class(cls: ClassInfo) -> str:
     lines = [
         "#### `{}`".format(cls.name),
         "",
-        "```python",
+        "```",
     ]
 
     if cls.decorators:
@@ -448,14 +448,14 @@ def render_method(method: MethodInfo) -> str:
     lines = [
         "##### `{}`".format(method.name),
         "",
-        "```python",
+        "```",
     ]
 
     if method.decorators:
         for dec in method.decorators:
             lines.append("@{}".format(dec))
 
-    lines.append("def {}{}{}".format(method.name, sig, ret))
+    lines.append("{}{}{}".format(method.name, sig, ret))
     lines.append("```")
     lines.append("")
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,96 @@
+"""
+Universal Parser for multi-language documentation generation.
+
+Provides a fallback parser for non-Python languages using regular expressions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+    ParseResult,
+    Visibility,
+)
+
+
+class UniversalParser(BaseParser):
+    """Regex-based fallback parser for generic programming languages."""
+
+    def language(self) -> str:
+        """Return the language identifier.
+
+        Returns:
+            The string "universal".
+        """
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        """Return supported file extensions.
+
+        Returns:
+            A list of common programming language extensions.
+        """
+        return [
+            ".js", ".ts", ".java", ".cpp", ".c", ".go", ".rs",
+            ".rb", ".php", ".cs", ".swift", ".kt", ".scala", ".m", ".h"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        """Parse a generic source file using simple regex rules.
+
+        Args:
+            file_path: Path to the source file.
+
+        Returns:
+            A populated ModuleInfo dataclass.
+        """
+        file_path = Path(file_path).resolve()
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        source = file_path.read_text(encoding="utf-8")
+        lines = source.splitlines()
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Simple regex patterns for common constructs across many languages
+        function_pattern = re.compile(r"^\s*(?:public\s+|private\s+|protected\s+|static\s+|export\s+|async\s+)*(?:function\s+|func\s+|def\s+|fn\s+|[\w<>\[\]]+\s+)([a-zA-Z_]\w*)\s*\(", re.MULTILINE)
+        class_pattern = re.compile(r"^\s*(?:public\s+|private\s+|protected\s+|export\s+)*(?:class|struct|interface)\s+([a-zA-Z_]\w*)", re.MULTILINE)
+
+        # Extract functions
+        for match in function_pattern.finditer(source):
+            func_name = match.group(1)
+            # Skip obvious false positives like control structures
+            if func_name in ("if", "for", "while", "switch", "catch"):
+                continue
+
+            # Estimate line number
+            line_idx = source[:match.start()].count("\n") + 1
+
+            module_info.functions.append(FunctionInfo(
+                name=func_name,
+                visibility=Visibility.PUBLIC, # Default assumption
+                start_line=line_idx,
+                end_line=line_idx
+            ))
+
+        # Extract classes
+        for match in class_pattern.finditer(source):
+            class_name = match.group(1)
+            line_idx = source[:match.start()].count("\n") + 1
+
+            module_info.classes.append(ClassInfo(
+                name=class_name,
+                visibility=Visibility.PUBLIC,
+                start_line=line_idx,
+                end_line=line_idx
+            ))
+
+        return module_info


### PR DESCRIPTION
- Adds `src/parser/universal_parser.py` which provides a fallback parser to extract functions and classes from a wide variety of programming languages via Regex.
- Updates `src/cli.py` to map universal file extensions to the new `UniversalParser` and registers it in the `ParserRegistry`.
- Refactors code to correctly parse and merge cross-language parse results.
- Modifies `src/generator/templates.py` to omit the Python language tag in Markdown codeblocks to be language-agnostic.

---
*PR created automatically by Jules for task [6707836756307167825](https://jules.google.com/task/6707836756307167825) started by @xorinf*