### PR TITLE
feat: implement universal parser for multi-language documentation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -190,14 +190,17 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+
+    parse_result = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
     elapsed = time.time() - start
 
     if not parse_result.modules:
-        logger.warning("No supported source files found in %s", input_dir)
-        logger.warning("Supported languages: %s", ", ".join(SUPPORTED_LANGUAGES))
+        logger.warning("No source files found in %s", input_dir)
         sys.exit(0)
 
     logger.info(
@@ -446,10 +449,6 @@ def _collect_source_files(
     Returns:
         A sorted list of Path objects pointing to source files.
     """
-    valid_extensions: set[str] = set()
-    for lang in SUPPORTED_LANGUAGES:
-        valid_extensions.update(_LANGUAGE_EXTENSIONS.get(lang, []))
-
     collected: list[Path] = []
 
     for dirpath, dirnames, filenames in os.walk(root):
@@ -458,8 +457,10 @@ def _collect_source_files(
             d for d in dirnames if d not in exclude_dirs
         ]
         for fname in filenames:
-            if Path(fname).suffix in valid_extensions:
-                collected.append(Path(dirpath) / fname)
+            # Skip hidden files or files without extensions typically not source
+            if fname.startswith(".") or not Path(fname).suffix:
+                continue
+            collected.append(Path(dirpath) / fname)
 
     return sorted(collected)
 

--- a/src/parser/registry.py
+++ b/src/parser/registry.py
@@ -38,7 +38,9 @@ class ParserRegistry:
 
     def __init__(self) -> None:
         """Initialize an empty registry."""
+        from src.parser.universal import UniversalParser
         self._parsers: dict[str, BaseParser] = {}
+        self._fallback_parser = UniversalParser()
 
     def register(self, parser: BaseParser) -> None:
         """Register a parser for all of its supported extensions.
@@ -52,7 +54,7 @@ class ParserRegistry:
         for ext in parser.supported_extensions():
             self._parsers[ext] = parser
 
-    def get_parser_for_file(self, file_path: Path) -> Optional[BaseParser]:
+    def get_parser_for_file(self, file_path: Path) -> BaseParser:
         """Look up the appropriate parser for a given file.
 
         Args:
@@ -60,9 +62,9 @@ class ParserRegistry:
 
         Returns:
             The registered BaseParser for the file's extension,
-            or None if no parser is registered for that extension.
+            or the Universal fallback parser if no parser is registered.
         """
-        return self._parsers.get(file_path.suffix)
+        return self._parsers.get(file_path.suffix, self._fallback_parser)
 
     def get_parser_for_extension(self, extension: str) -> Optional[BaseParser]:
         """Look up the appropriate parser for a given extension string.
@@ -88,32 +90,47 @@ class ParserRegistry:
         self,
         root: Path,
         exclude_dirs: Optional[list[str]] = None,
-    ) -> list[ParseResult]:
-        """Run every registered parser across the given directory.
+    ) -> ParseResult:
+        """Parse all files in the given directory using appropriate parsers.
 
-        Each unique parser instance is invoked once with its own
-        parse_directory call. Duplicate parser references (registered
-        under multiple extensions) are deduplicated.
+        Walks the directory tree, skipping excluded directories, and uses
+        the specific parser registered for each file's extension, or falls
+        back to the UniversalParser.
 
         Args:
             root: The root directory to search.
             exclude_dirs: Directory names to skip during traversal.
 
         Returns:
-            A list of ParseResult objects, one per unique parser.
+            A single combined ParseResult containing all parsed modules.
         """
-        seen: set[int] = set()
-        results: list[ParseResult] = []
+        import os
 
-        for parser in self._parsers.values():
-            pid = id(parser)
-            if pid in seen:
-                continue
-            seen.add(pid)
-            result = parser.parse_directory(root, exclude_dirs)
-            results.append(result)
+        if exclude_dirs is None:
+            exclude_dirs = []
 
-        return results
+        combined_result = ParseResult(language="mixed")
+
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
+
+            for fname in filenames:
+                if fname.startswith(".") or not Path(fname).suffix:
+                    continue
+
+                fpath = Path(dirpath) / fname
+                parser = self.get_parser_for_file(fpath)
+
+                try:
+                    module_info = parser.parse_file(fpath)
+                    # Exclude empty modules parsed by universal parser
+                    if parser.language() == "universal" and not module_info.classes and not module_info.functions:
+                        continue
+                    combined_result.modules.append(module_info)
+                except Exception as exc:
+                    combined_result.errors.append(f"{fpath}: {exc}")
+
+        return combined_result
 
     def __len__(self) -> int:
         """Return the number of registered extensions."""

--- a/src/parser/universal.py
+++ b/src/parser/universal.py
@@ -1,0 +1,77 @@
+"""
+universal.py -- Fallback Parser for Unsupported Languages.
+
+Uses a broad, regex-based approach to extract basic class and
+function structures from any text-based source file when a dedicated
+language parser is not available.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+    ParseResult,
+    Visibility,
+)
+
+class UniversalParser(BaseParser):
+    """Regex-based fallback parser for unsupported languages."""
+
+    def __init__(self) -> None:
+        self._class_pattern = re.compile(
+            r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|abstract\s+|sealed\s+)*(?:class|struct|interface|trait|enum)\s+([A-Za-z_][A-Za-z0-9_]*)",
+            re.MULTILINE
+        )
+
+        self._func_kw_pattern = re.compile(
+            r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|static\s+|async\s+|inline\s+)*(?:def|function|fn|func)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(",
+            re.MULTILINE
+        )
+
+        self._c_func_pattern = re.compile(
+            r"^\s*(?:export\s+|public\s+|private\s+|protected\s+|static\s+|virtual\s+|inline\s+|override\s+|final\s+)*[A-Za-z_][A-Za-z0-9_<>\[\]]*\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(",
+            re.MULTILINE
+        )
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return []
+
+    def can_parse(self, file_path: Path) -> bool:
+        return True
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        file_path = Path(file_path).resolve()
+        module_info = ModuleInfo(file_path=file_path)
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except Exception:
+            return module_info
+
+        for match in self._class_pattern.finditer(content):
+            class_name = match.group(1)
+            module_info.classes.append(ClassInfo(name=class_name))
+
+        found_funcs = set()
+        for match in self._func_kw_pattern.finditer(content):
+            func_name = match.group(1)
+            found_funcs.add(func_name)
+            module_info.functions.append(FunctionInfo(name=func_name))
+
+        for match in self._c_func_pattern.finditer(content):
+            func_name = match.group(1)
+            if func_name not in found_funcs and func_name not in ("if", "for", "while", "catch", "switch"):
+                found_funcs.add(func_name)
+                module_info.functions.append(FunctionInfo(name=func_name))
+
+        return module_info


### PR DESCRIPTION
This PR fulfills the project roadmap goal to generate docs for any language. It introduces a `UniversalParser` as a fallback mechanism for any unsupported language files using regex patterns, correctly wires it up via `ParserRegistry`, and updates the CLI to process multiple languages.

---
*PR created automatically by Jules for task [2307901405781170295](https://jules.google.com/task/2307901405781170295) started by @xorinf*