### PR TITLE
feat: Add UniversalParser to support any language

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +190,15 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_result = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -271,7 +277,15 @@ def _handle_analyze(args: argparse.Namespace) -> None:
 
     logger.info("Analyzing codebase at: %s", input_dir)
 
-    source_files = _collect_source_files(input_dir, config.get("exclude", []))
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    source_files = _collect_source_files(input_dir, config.get("exclude", []), registry)
 
     if not source_files:
         logger.warning("No supported source files found in %s", input_dir)
@@ -428,35 +442,29 @@ def _handle_version(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 # Map of supported language names to their file extensions.
-_LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
-    "python": [".py"],
-}
+
 
 
 def _collect_source_files(
     root: Path,
     exclude_dirs: list[str],
+    registry,
 ) -> list[Path]:
     """Walk the directory tree and collect supported source files.
 
     Args:
         root: The root directory to search.
         exclude_dirs: Directory names to skip during traversal.
+        registry: The ParserRegistry instance containing supported extensions.
 
     Returns:
         A sorted list of Path objects pointing to source files.
     """
-    valid_extensions: set[str] = set()
-    for lang in SUPPORTED_LANGUAGES:
-        valid_extensions.update(_LANGUAGE_EXTENSIONS.get(lang, []))
-
+    valid_extensions = set(registry.supported_extensions())
     collected: list[Path] = []
 
     for dirpath, dirnames, filenames in os.walk(root):
-        # Prune excluded directories in-place so os.walk skips them.
-        dirnames[:] = [
-            d for d in dirnames if d not in exclude_dirs
-        ]
+        dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
         for fname in filenames:
             if Path(fname).suffix in valid_extensions:
                 collected.append(Path(dirpath) / fname)

--- a/src/parser/registry.py
+++ b/src/parser/registry.py
@@ -88,32 +88,42 @@ class ParserRegistry:
         self,
         root: Path,
         exclude_dirs: Optional[list[str]] = None,
-    ) -> list[ParseResult]:
-        """Run every registered parser across the given directory.
+    ) -> ParseResult:
+        """Walk the given directory and parse all supported files.
 
-        Each unique parser instance is invoked once with its own
-        parse_directory call. Duplicate parser references (registered
-        under multiple extensions) are deduplicated.
+        Uses the registered parsers to process each file appropriately based
+        on its extension.
 
         Args:
             root: The root directory to search.
             exclude_dirs: Directory names to skip during traversal.
 
         Returns:
-            A list of ParseResult objects, one per unique parser.
+            A single ParseResult object containing modules from all languages.
         """
-        seen: set[int] = set()
-        results: list[ParseResult] = []
+        import os
 
-        for parser in self._parsers.values():
-            pid = id(parser)
-            if pid in seen:
-                continue
-            seen.add(pid)
-            result = parser.parse_directory(root, exclude_dirs)
-            results.append(result)
+        if exclude_dirs is None:
+            exclude_dirs = []
 
-        return results
+        result = ParseResult(language="mixed")
+
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
+
+            for fname in filenames:
+                fpath = Path(dirpath) / fname
+                parser = self.get_parser_for_file(fpath)
+
+                if parser:
+                    try:
+                        module_info = parser.parse_file(fpath)
+                        result.modules.append(module_info)
+                    except Exception as exc:
+                        result.errors.append(f"{fpath}: {exc}")
+
+        return result
+
 
     def __len__(self) -> int:
         """Return the number of registered extensions."""

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,60 @@
+import re
+from pathlib import Path
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+    Visibility,
+)
+
+class UniversalParser(BaseParser):
+    """Fallback parser using regex to extract functions and classes for non-Python files."""
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return [
+            ".js", ".jsx", ".ts", ".tsx", ".java", ".cpp", ".c", ".h",
+            ".cs", ".go", ".rs", ".php", ".rb"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        file_path = Path(file_path).resolve()
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            source = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Skip binary files or files with unknown encoding
+            return ModuleInfo(file_path=file_path)
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Basic regex to extract function names
+        # Matches: def func_name(, function func_name(, func func_name(
+        func_pattern = re.compile(r'\b(?:def|function|func|fn)\s+([a-zA-Z_]\w*)\s*\(', re.MULTILINE)
+        for match in func_pattern.finditer(source):
+            func_name = match.group(1)
+            visibility = Visibility.PRIVATE if func_name.startswith('_') else Visibility.PUBLIC
+            module_info.functions.append(FunctionInfo(
+                name=func_name,
+                visibility=visibility,
+            ))
+
+        # Basic regex to extract class names
+        # Matches: class ClassName
+        class_pattern = re.compile(r'\bclass\s+([a-zA-Z_]\w*)', re.MULTILINE)
+        for match in class_pattern.finditer(source):
+            class_name = match.group(1)
+            visibility = Visibility.PRIVATE if class_name.startswith('_') else Visibility.PUBLIC
+            module_info.classes.append(ClassInfo(
+                name=class_name,
+                visibility=visibility,
+            ))
+
+        return module_info

--- a/tests/test_universal_parser.py
+++ b/tests/test_universal_parser.py
@@ -1,0 +1,46 @@
+import unittest
+from pathlib import Path
+from src.parser.universal_parser import UniversalParser
+
+class TestUniversalParser(unittest.TestCase):
+    def setUp(self):
+        self.parser = UniversalParser()
+        self.test_file = Path("test_dummy.js")
+        self.test_file.write_text("""
+function myPublicFunc() {
+    console.log("hello");
+}
+
+function _myPrivateFunc() {
+    console.log("private");
+}
+
+class MyPublicClass {
+    constructor() {}
+}
+
+class _MyPrivateClass {
+    constructor() {}
+}
+""")
+
+    def tearDown(self):
+        if self.test_file.exists():
+            self.test_file.unlink()
+
+    def test_parse_file(self):
+        module = self.parser.parse_file(self.test_file)
+        self.assertEqual(len(module.functions), 2)
+        self.assertEqual(module.functions[0].name, "myPublicFunc")
+        self.assertEqual(module.functions[0].visibility.value, "public")
+        self.assertEqual(module.functions[1].name, "_myPrivateFunc")
+        self.assertEqual(module.functions[1].visibility.value, "private")
+
+        self.assertEqual(len(module.classes), 2)
+        self.assertEqual(module.classes[0].name, "MyPublicClass")
+        self.assertEqual(module.classes[0].visibility.value, "public")
+        self.assertEqual(module.classes[1].name, "_MyPrivateClass")
+        self.assertEqual(module.classes[1].visibility.value, "private")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added `UniversalParser` to support parsing non-Python languages using regular expressions as a fallback mechanism, satisfying the roadmap goal to generate documentation for any language. Modified `ParserRegistry` to seamlessly aggregate results from multiple languages into a single result, and integrated these changes into the main CLI.

---
*PR created automatically by Jules for task [16985786465927782836](https://jules.google.com/task/16985786465927782836) started by @xorinf*