### PR TITLE
feat: Add UniversalParser to support non-Python languages

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,14 +29,13 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
     "version": APP_VERSION,
     "input": ".",
     "output": DEFAULT_OUTPUT_DIR,
-    "languages": SUPPORTED_LANGUAGES,
+    "languages": ["python", "universal"],
     "exclude": [
         "__pycache__",
         ".git",
@@ -190,14 +189,26 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    parse_result = ParseResult(language="mixed")
+    for r in results:
+        parse_result.modules.extend(r.modules)
+        parse_result.errors.extend(r.errors)
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
         logger.warning("No supported source files found in %s", input_dir)
-        logger.warning("Supported languages: %s", ", ".join(SUPPORTED_LANGUAGES))
         sys.exit(0)
 
     logger.info(
@@ -271,20 +282,43 @@ def _handle_analyze(args: argparse.Namespace) -> None:
 
     logger.info("Analyzing codebase at: %s", input_dir)
 
-    source_files = _collect_source_files(input_dir, config.get("exclude", []))
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
 
-    if not source_files:
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    parse_result = ParseResult(language="mixed")
+    for r in results:
+        parse_result.modules.extend(r.modules)
+        parse_result.errors.extend(r.errors)
+
+    if not parse_result.modules:
         logger.warning("No supported source files found in %s", input_dir)
         sys.exit(0)
 
-    logger.info("Detected %d source file(s):", len(source_files))
-    for f in source_files:
-        rel = f.relative_to(input_dir)
-        size = f.stat().st_size
+    logger.info("Parsed %d source file(s):", len(parse_result.modules))
+    for m in parse_result.modules:
+        try:
+            rel = m.file_path.relative_to(input_dir)
+        except ValueError:
+            rel = m.file_path
+        size = m.file_path.stat().st_size if m.file_path.exists() else 0
         logger.info("  %-40s  %d bytes", str(rel), size)
 
-    # TODO: Wire into src.parser and src.analyzer once implemented.
-    logger.info("Deep analysis pending implementation (Phase 2).")
+    from src.analyzer.analyzer import SemanticAnalyzer
+    analyzer = SemanticAnalyzer(project_root=input_dir)
+    analysis = analyzer.analyze(parse_result)
+
+    logger.info("Analysis complete.")
+    logger.info("  Total Modules : %d", analysis.codebase_stats.total_modules)
+    logger.info("  Total Classes : %d", analysis.codebase_stats.total_classes)
+    logger.info("  Total Functions: %d", analysis.codebase_stats.total_functions)
 
 
 def _handle_scrape(args: argparse.Namespace) -> None:
@@ -446,9 +480,15 @@ def _collect_source_files(
     Returns:
         A sorted list of Path objects pointing to source files.
     """
-    valid_extensions: set[str] = set()
-    for lang in SUPPORTED_LANGUAGES:
-        valid_extensions.update(_LANGUAGE_EXTENSIONS.get(lang, []))
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    valid_extensions = set(registry.supported_extensions())
 
     collected: list[Path] = []
 

--- a/src/parser/__init__.py
+++ b/src/parser/__init__.py
@@ -11,4 +11,10 @@ Architecture:
     - registry.py  : A central registry that maps file extensions to
                      their corresponding parser implementations.
     - python_parser.py : (Future) Concrete parser for Python source files.
+    - universal_parser.py : Fallback parser for non-Python languages.
 """
+
+from src.parser.python_parser import PythonParser
+from src.parser.universal_parser import UniversalParser
+
+__all__ = ["PythonParser", "UniversalParser"]

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,56 @@
+import re
+from pathlib import Path
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+)
+
+class UniversalParser(BaseParser):
+    """Fallback parser for multiple languages using regular expressions.
+
+    Extracts basic class and function structures from non-Python languages.
+    """
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return [
+            ".js", ".ts", ".java", ".cpp", ".c", ".cs", ".go", ".rs", ".php", ".rb",
+            ".swift", ".kt"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        file_path = Path(file_path).resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        source = file_path.read_text(encoding="utf-8", errors="ignore")
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Naive regex for classes
+        class_regex = re.compile(r'\b(?:class|struct|interface)\s+([a-zA-Z_]\w*)')
+
+        # Naive regex for functions/methods
+        func_regex = re.compile(
+            r'\b(?:def|function|func|fn|public|private|protected|static|virtual|inline|const|abstract|override|[\w<>\[\]]+)\s+([a-zA-Z_]\w*)\s*\([^)]*\)\s*(?:\{|:|->|throws)'
+        )
+
+        for line_no, line in enumerate(source.splitlines(), start=1):
+            class_match = class_regex.search(line)
+            if class_match:
+                name = class_match.group(1)
+                module_info.classes.append(ClassInfo(name=name, start_line=line_no, end_line=line_no))
+                continue
+
+            func_match = func_regex.search(line)
+            if func_match:
+                name = func_match.group(1)
+                # Ignore common keywords
+                if name not in ("if", "for", "while", "switch", "catch", "return", "class", "else", "elif"):
+                    module_info.functions.append(FunctionInfo(name=name, start_line=line_no, end_line=line_no))
+
+        return module_info


### PR DESCRIPTION
Closes #1

This PR adds a regex-based UniversalParser to act as a fallback and support documentation generation for languages not natively parsed. It also wires up the parser into the main CLI commands `analyze` and `generate`, by gathering their results in a mixed `ParseResult` for the semantic analyzer.

---
*PR created automatically by Jules for task [4374004885563031137](https://jules.google.com/task/4374004885563031137) started by @xorinf*