### PR TITLE
Add UniversalParser for multi-language support

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +190,22 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    from src.parser.base import ParseResult
+    parse_result = ParseResult(language="mixed")
+    for res in parse_results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -283,8 +296,36 @@ def _handle_analyze(args: argparse.Namespace) -> None:
         size = f.stat().st_size
         logger.info("  %-40s  %d bytes", str(rel), size)
 
-    # TODO: Wire into src.parser and src.analyzer once implemented.
-    logger.info("Deep analysis pending implementation (Phase 2).")
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    from src.parser.base import ParseResult
+    parse_result = ParseResult(language="mixed")
+    for res in parse_results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+
+    if not parse_result.modules:
+        logger.warning("No supported source files found for analysis.")
+        sys.exit(0)
+
+    from src.analyzer.analyzer import SemanticAnalyzer
+    analyzer = SemanticAnalyzer(project_root=input_dir)
+    analysis = analyzer.analyze(parse_result)
+
+    logger.info(
+        "Analysis complete: %d modules, %d dependencies, %d classes in hierarchy",
+        len(parse_result.modules),
+        len(analysis.dependency_graph.edges),
+        len(analysis.inheritance_tree.nodes)
+    )
 
 
 def _handle_scrape(args: argparse.Namespace) -> None:
@@ -430,6 +471,10 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "universal": [
+        ".js", ".ts", ".java", ".cpp", ".c", ".go", ".rb", ".php", ".cs",
+        ".rs", ".swift", ".kt", ".m", ".h", ".hpp", ".scala"
+    ],
 }
 
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    MethodInfo,
+    ModuleInfo,
+    Parameter,
+    ParseResult,
+    Visibility,
+)
+
+
+class UniversalParser(BaseParser):
+    """Regex-based fallback parser for extracting basic structures from non-Python languages."""
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return [
+            ".js", ".ts", ".java", ".cpp", ".c", ".go", ".rb", ".php", ".cs",
+            ".rs", ".swift", ".kt", ".m", ".h", ".hpp", ".scala"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        """Parse a single source file into a ModuleInfo structure."""
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Fallback for potentially weird encodings
+            content = file_path.read_text(encoding="latin-1")
+
+        lines = content.splitlines()
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Regex patterns
+        # Very basic class matching: `class Foo`, `class Foo extends Bar`, `class Foo {`
+        class_pattern = re.compile(r'^\s*(?:public\s+|private\s+|protected\s+)?(?:abstract\s+)?class\s+([a-zA-Z_]\w*)', re.MULTILINE)
+
+        # Very basic function/method matching: `function foo(...)`, `def foo(...)`, `func foo(...)`, `void foo(...)`, `int foo(...)`
+        # We try to capture things that look like function definitions.
+        func_pattern = re.compile(r'^\s*(?:public\s+|private\s+|protected\s+|static\s+|async\s+)*(?:function|def|func|void|int|string|bool|float|double|char|long|short)\s+([a-zA-Z_]\w*)\s*\([^)]*\)', re.MULTILINE)
+
+        # Find classes
+        for match in class_pattern.finditer(content):
+            class_name = match.group(1)
+            # We don't have perfect line numbers with this simple regex, but we can approximate or leave as 0
+            # A more robust approach would iterate over lines, but for a fallback this is acceptable
+            module_info.classes.append(
+                ClassInfo(name=class_name)
+            )
+
+        # Find functions
+        for match in func_pattern.finditer(content):
+            func_name = match.group(1)
+            # If it's a known language construct we could try to differentiate methods vs functions,
+            # but UniversalParser is a fallback and doesn't know context. We'll just add as function.
+            module_info.functions.append(
+                FunctionInfo(name=func_name)
+            )
+
+        return module_info


### PR DESCRIPTION
Added a regex-based UniversalParser to support documentation generation for a wide variety of programming languages beyond Python, and integrated it into the CLI pipeline using ParserRegistry.

---
*PR created automatically by Jules for task [11677866809803582957](https://jules.google.com/task/11677866809803582957) started by @xorinf*