### PR TITLE
feat: universal parser for multi-language support

### DIFF
--- a/docs/__init__.md
+++ b/docs/__init__.md
@@ -2,17 +2,8 @@
 
 ## `__init__.py`
 
-src.analyzer -- Semantic Analysis Package.
-
-This package analyzes parsed code structures to understand relationships,
-dependencies, and architectural patterns. It produces structured analysis
-results consumed by the generator module.
-
-Public API:
-    - SemanticAnalyzer: The main analysis engine.
-    - AnalysisResult: Top-level output container.
-    - DependencyGraph, InheritanceTree: Relationship models.
-    - ModuleMetrics, CodebaseStats: Quantitative outputs.
+Tokenizer package for CodeScribe.
+Provides utilities to train and manage the custom Byte-Level BPE tokenizer.
 
 ### Module Statistics
 
@@ -21,15 +12,14 @@ Public API:
 | Functions | 0 |
 | Classes | 0 |
 | Methods | 0 |
-| Imports | 2 |
-| Lines | 31 |
+| Imports | 0 |
+| Lines | 14 |
 | Doc Coverage | 0% |
 
 ### Imports
 
 ```python
-from src.analyzer.analyzer import SemanticAnalyzer
-from src.analyzer.models import AnalysisResult, CodebaseStats, DependencyGraph, InheritanceTree, ModuleMetrics
+from trainer import CodeTokenizerTrainer
 ```
 
 ### Module-Level Variables

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,11 +18,11 @@ Usage:
 
 | Metric | Value |
 |---|---|
-| Functions | 11 |
+| Functions | 14 |
 | Classes | 0 |
 | Methods | 0 |
 | Imports | 8 |
-| Lines | 503 |
+| Lines | 736 |
 | Doc Coverage | 100% |
 
 ### Imports
@@ -56,7 +56,7 @@ from typing import Optional
 def main() -> None
 ```
 
-(public) | Lines 494-503
+(public) | Lines 727-736
 
 Parse arguments and dispatch to the appropriate subcommand handler.
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,0 +1,67 @@
+---
+
+## `engine.py`
+
+Scraping engine orchestrator.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 8 |
+| Lines | 83 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+from github import GitHubScraper
+from gitlab import GitLabScraper
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `AsyncScraperEngine`
+
+```python
+class AsyncScraperEngine
+```
+
+(public) | Lines 18-83
+
+Orchestrates asynchronous repository discovery and ingestion.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `ingest_repositories` | public | - | - |
+
+##### `ingest_repositories`
+
+```python
+def ingest_repositories(platform: str, query: str, output_dir: Path, limit: int = 100, download_source: bool = True)
+```
+
+Main ingestion pipeline.
+
+| Name | Type | Default |
+|---|---|---|
+| `platform` | `str` | - |
+| `query` | `str` | - |
+| `output_dir` | `Path` | - |
+| `limit` | `int` | `100` |
+| `download_source` | `bool` | `True` |

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,0 +1,84 @@
+---
+
+## `github.py`
+
+GitHub scraper integration for CodeScribe.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 7 |
+| Imports | 8 |
+| Lines | 152 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import AsyncGenerator, List, Optional, Dict, Any
+import aiohttp
+import aiofiles
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `GitHubScraper`
+
+```python
+class GitHubScraper
+```
+
+(public) | Lines 18-152
+
+Handles asynchronous scraping of GitHub repositories.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `search_repositories` | public | - | - |
+| `download_zipball` | public | - | - |
+
+##### `search_repositories`
+
+```python
+def search_repositories(query: str, sort: str = 'stars', order: str = 'desc', limit: int = 100) -> AsyncGenerator[RepositoryMetadata, None]
+```
+
+Search for repositories on GitHub and yield metadata.
+
+| Name | Type | Default |
+|---|---|---|
+| `query` | `str` | - |
+| `sort` | `str` | `'stars'` |
+| `order` | `str` | `'desc'` |
+| `limit` | `int` | `100` |
+
+**Returns:** `AsyncGenerator[RepositoryMetadata, None]`
+
+##### `download_zipball`
+
+```python
+def download_zipball(repo: RepositoryMetadata, output_dir: Path) -> Optional[Path]
+```
+
+Download the repository zipball.
+
+| Name | Type | Default |
+|---|---|---|
+| `repo` | `RepositoryMetadata` | - |
+| `output_dir` | `Path` | - |
+
+**Returns:** `Optional[Path]`

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -1,0 +1,79 @@
+---
+
+## `gitlab.py`
+
+GitLab scraper integration for CodeScribe.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 3 |
+| Lines | 29 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import logging
+from typing import AsyncGenerator, List, Optional
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `GitLabScraper`
+
+```python
+class GitLabScraper
+```
+
+(public) | Lines 11-29
+
+Handles asynchronous scraping of GitLab repositories. (Stub implementation)
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `search_repositories` | public | - | - |
+| `download_zipball` | public | - | - |
+
+##### `search_repositories`
+
+```python
+def search_repositories(query: str, sort: str = 'stars', order: str = 'desc', limit: int = 100) -> AsyncGenerator[RepositoryMetadata, None]
+```
+
+Search for repositories on GitLab (Not yet fully implemented).
+
+| Name | Type | Default |
+|---|---|---|
+| `query` | `str` | - |
+| `sort` | `str` | `'stars'` |
+| `order` | `str` | `'desc'` |
+| `limit` | `int` | `100` |
+
+**Returns:** `AsyncGenerator[RepositoryMetadata, None]`
+
+##### `download_zipball`
+
+```python
+def download_zipball(repo: RepositoryMetadata, output_dir: str) -> Optional[str]
+```
+
+Download the repository zipball from GitLab (Not yet fully implemented).
+
+| Name | Type | Default |
+|---|---|---|
+| `repo` | `RepositoryMetadata` | - |
+| `output_dir` | `str` | - |
+
+**Returns:** `Optional[str]`

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -1,0 +1,75 @@
+---
+
+## `heuristics.py`
+
+Quality and heuristic filters for CodeScribe Data Cleanser.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 3 |
+| Lines | 69 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import re
+import logging
+from typing import Optional
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `QualityFilter`
+
+```python
+class QualityFilter
+```
+
+(public) | Lines 11-69
+
+Applies heuristic checks to filter out low-quality code or boilerplate.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `is_auto_generated` | public | - | - |
+| `is_high_quality` | public | - | - |
+
+##### `is_auto_generated`
+
+```python
+def is_auto_generated(content: str) -> bool
+```
+
+Check if the first few lines contain auto-generated markers.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`
+
+##### `is_high_quality`
+
+```python
+def is_high_quality(content: str) -> bool
+```
+
+Main heuristic check for file content.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,12 @@
 
 | Metric | Value |
 |---|---|
-| Language | Python |
-| Total Modules | 13 |
-| Total Functions | 31 |
-| Total Classes | 21 |
-| Total Methods | 47 |
-| Estimated Lines | 3228 |
+| Language | Mixed |
+| Total Modules | 26 |
+| Total Functions | 34 |
+| Total Classes | 30 |
+| Total Methods | 75 |
+| Estimated Lines | 4222 |
 | Documentation Coverage | 100% |
 
 **Most complex module**: `src.parser.python_parser`
@@ -21,15 +21,28 @@
 
 - [__init__](__init__.md)
 - [__init__](__init__.md)
+- [__init__](__init__.md)
+- [__init__](__init__.md)
+- [__init__](__init__.md)
 - [analyzer](analyzer.md)
 - [base](base.md)
 - [cli](cli.md)
+- [engine](engine.md)
 - [generator](generator.md)
+- [github](github.md)
+- [gitlab](gitlab.md)
+- [heuristics](heuristics.md)
+- [models](models.md)
 - [models](models.md)
 - [nlp](nlp.md)
+- [pipeline](pipeline.md)
 - [python_parser](python_parser.md)
 - [registry](registry.md)
+- [secrets](secrets.md)
 - [templates](templates.md)
+- [test_regex](test_regex.md)
+- [trainer](trainer.md)
+- [universal](universal.md)
 
 ---
 
@@ -39,27 +52,42 @@
 
 | Source | Target | Imported Names |
 |---|---|---|
-| `src.parser.registry` | `src.parser.base` | BaseParser, ParseResult |
-| `src.parser.python_parser` | `src.parser.base` | BaseParser, ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
-| `src.generator` | `src.generator.generator` | DocGenerator |
-| `src.generator.templates` | `src.parser.base` | ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
-| `src.generator.templates` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, InheritanceNode, ModuleMetrics |
+| `src.cleanser.pipeline` | `heuristics` | QualityFilter |
+| `src.cleanser.pipeline` | `secrets` | SecretScanner |
+| `src.cleanser` | `pipeline` | CleanserPipeline |
+| `src.scraper.gitlab` | `models` | RepositoryMetadata |
+| `src.scraper.github` | `models` | RepositoryMetadata |
+| `src.scraper` | `engine` | AsyncScraperEngine |
+| `src.scraper` | `models` | RepositoryMetadata |
+| `src.scraper.engine` | `github` | GitHubScraper |
+| `src.scraper.engine` | `gitlab` | GitLabScraper |
+| `src.scraper.engine` | `models` | RepositoryMetadata |
 | `src.generator.nlp` | `src.parser.base` | ClassInfo, FunctionInfo |
+| `src.generator` | `src.generator.generator` | DocGenerator |
 | `src.generator.generator` | `src.parser.base` | ModuleInfo, ParseResult, FunctionInfo, ClassInfo |
 | `src.generator.generator` | `src.analyzer.models` | AnalysisResult, ModuleMetrics |
 | `src.generator.generator` | `src.generator` | templates |
 | `src.generator.generator` | `src.generator.nlp` | NLPEngine |
-| `src.analyzer.analyzer` | `src.parser.base` | ClassInfo, FunctionInfo, ModuleInfo, ParseResult, Visibility |
-| `src.analyzer.analyzer` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, DependencyGraph, InheritanceNode, InheritanceTree, ModuleMetrics |
+| `src.generator.templates` | `src.parser.base` | ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
+| `src.generator.templates` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, InheritanceNode, ModuleMetrics |
 | `src.analyzer` | `src.analyzer.analyzer` | SemanticAnalyzer |
 | `src.analyzer` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyGraph, InheritanceTree, ModuleMetrics |
+| `src.analyzer.analyzer` | `src.parser.base` | ClassInfo, FunctionInfo, ModuleInfo, ParseResult, Visibility |
+| `src.analyzer.analyzer` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, DependencyGraph, InheritanceNode, InheritanceTree, ModuleMetrics |
+| `src.tokenizer` | `trainer` | CodeTokenizerTrainer |
+| `src.parser.registry` | `src.parser.base` | BaseParser, ParseResult |
+| `src.parser.universal` | `src.parser.base` | BaseParser, ClassInfo, FunctionInfo, ModuleInfo, ParseResult, Visibility |
+| `src.parser.python_parser` | `src.parser.base` | BaseParser, ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
 
 ### External Dependencies
 
 - `__future__`
 - `abc`
+- `aiofiles`
+- `aiohttp`
 - `argparse`
 - `ast`
+- `asyncio`
 - `collections`
 - `dataclasses`
 - `enum`
@@ -67,13 +95,21 @@
 - `logging`
 - `os`
 - `pathlib`
+- `re`
 - `sys`
 - `time`
+- `tokenizers`
 - `typing`
+- `zipfile`
 
 ---
 
 ## Class Hierarchy
+
+- **UniversalParser** (depth: 1)
+  - Inherits from: BaseParser
+  - Subclassed by: none
+  - Defined in: `src.parser.universal`
 
 - **PythonParser** (depth: 1)
   - Inherits from: BaseParser
@@ -87,5 +123,5 @@
 
 - **BaseParser** (depth: 0)
   - Inherits from: ABC
-  - Subclassed by: PythonParser
+  - Subclassed by: UniversalParser, PythonParser
   - Defined in: `src.parser.base`

--- a/docs/nlp.md
+++ b/docs/nlp.md
@@ -22,7 +22,7 @@ Usage:
 | Classes | 1 |
 | Methods | 6 |
 | Imports | 5 |
-| Lines | 153 |
+| Lines | 156 |
 | Doc Coverage | 100% |
 
 ### Imports
@@ -47,7 +47,7 @@ from src.parser.base import ClassInfo, FunctionInfo
 class NLPEngine
 ```
 
-(public) | Lines 26-153
+(public) | Lines 26-156
 
 Natural Language Processing engine for enhancing documentation.
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,64 @@
+---
+
+## `pipeline.py`
+
+Data cleansing pipeline for CodeScribe.
+Extracts files from zipballs, applies filters, and writes cleaned data to JSONL.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 7 |
+| Lines | 100 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import json
+import logging
+import zipfile
+from pathlib import Path
+from typing import List, Set
+from heuristics import QualityFilter
+from secrets import SecretScanner
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `CleanserPipeline`
+
+```python
+class CleanserPipeline
+```
+
+(public) | Lines 17-100
+
+Orchestrates the extraction and cleansing of scraped repositories.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `process_directory` | public | - | - |
+
+##### `process_directory`
+
+```python
+def process_directory(input_dir: Path, output_file: Path)
+```
+
+Process all zipballs in a directory and write to a JSONL file.
+
+| Name | Type | Default |
+|---|---|---|
+| `input_dir` | `Path` | - |
+| `output_file` | `Path` | - |

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,60 @@
+---
+
+## `secrets.py`
+
+Secret scanning heuristics for CodeScribe Data Cleanser.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 1 |
+| Imports | 3 |
+| Lines | 36 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import re
+import logging
+from typing import List
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `SecretScanner`
+
+```python
+class SecretScanner
+```
+
+(public) | Lines 11-36
+
+Scans code for common secrets (PII, tokens, keys).
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `has_secrets` | public | - | - |
+
+##### `has_secrets`
+
+```python
+def has_secrets(content: str) -> bool
+```
+
+Check if the content contains any matched secrets.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`

--- a/docs/test_regex.md
+++ b/docs/test_regex.md
@@ -1,0 +1,26 @@
+---
+
+## `test_regex.py`
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 0 |
+| Methods | 0 |
+| Imports | 1 |
+| Lines | 24 |
+| Doc Coverage | 0% |
+
+### Imports
+
+```python
+import re
+```
+
+### Module-Level Variables
+
+- `code`
+- `class_pattern`
+- `func_pattern`

--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -1,0 +1,61 @@
+---
+
+## `trainer.py`
+
+Trainer for the CodeScribe custom BPE tokenizer.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 5 |
+| Lines | 82 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import json
+import logging
+from pathlib import Path
+from typing import Iterator
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `CodeTokenizerTrainer`
+
+```python
+class CodeTokenizerTrainer
+```
+
+(public) | Lines 15-82
+
+Trains a Byte-Level BPE tokenizer on a JSONL dataset.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `train` | public | - | - |
+
+##### `train`
+
+```python
+def train(dataset_path: Path, output_path: Path)
+```
+
+Train the tokenizer and save it.
+
+| Name | Type | Default |
+|---|---|---|
+| `dataset_path` | `Path` | - |
+| `output_path` | `Path` | - |

--- a/docs/universal.md
+++ b/docs/universal.md
@@ -1,0 +1,83 @@
+---
+
+## `universal.py`
+
+Universal Regex-Based Parser.
+
+A fallback parser that uses regular expressions to extract basic
+class and function structures from unsupported languages.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 4 |
+| Imports | 5 |
+| Lines | 114 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import Optional
+from src.parser.base import BaseParser, ClassInfo, FunctionInfo, ModuleInfo, ParseResult, Visibility
+```
+
+### Classes
+
+#### `UniversalParser`
+
+```python
+class UniversalParser(BaseParser)
+```
+
+(public) | Lines 24-114
+
+Regex-based parser for general programming languages.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `language` | public | - | - |
+| `supported_extensions` | public | - | - |
+| `parse_file` | public | - | - |
+
+##### `language`
+
+```python
+def language() -> str
+```
+
+Return the language identifier.
+
+**Returns:** `str`
+
+##### `supported_extensions`
+
+```python
+def supported_extensions() -> list[str]
+```
+
+Return supported file extensions.
+
+**Returns:** `list[str]`
+
+##### `parse_file`
+
+```python
+def parse_file(file_path: Path) -> ModuleInfo
+```
+
+Parse a file using regex to find classes and functions.
+
+| Name | Type | Default |
+|---|---|---|
+| `file_path` | `Path` | - |
+
+**Returns:** `ModuleInfo`

--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,19 +190,33 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    # Combine results for SemanticAnalyzer
+    combined_result = ParseResult(language="mixed")
+    for result in parse_results:
+        combined_result.modules.extend(result.modules)
+        combined_result.errors.extend(result.errors)
+
     elapsed = time.time() - start
 
-    if not parse_result.modules:
+    if not combined_result.modules:
         logger.warning("No supported source files found in %s", input_dir)
         logger.warning("Supported languages: %s", ", ".join(SUPPORTED_LANGUAGES))
         sys.exit(0)
 
     logger.info(
         "  Parsed %d module(s) in %.2fs",
-        len(parse_result.modules),
+        len(combined_result.modules),
         elapsed,
     )
 
@@ -214,7 +228,7 @@ def _handle_generate(args: argparse.Namespace) -> None:
     
     from src.analyzer.analyzer import SemanticAnalyzer
     analyzer = SemanticAnalyzer(project_root=input_dir)
-    analysis = analyzer.analyze(parse_result)
+    analysis = analyzer.analyze(combined_result)
     
     logger.info(
         "  Analyzed %d classes and %d dependencies in %.2fs",
@@ -242,7 +256,7 @@ def _handle_generate(args: argparse.Namespace) -> None:
     )
     
     files = generator.generate(
-        parse_result, analysis, output_dir, single_file=False
+        combined_result, analysis, output_dir, single_file=False
     )
     
     logger.info(
@@ -430,6 +444,13 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "universal": [
+        ".js", ".jsx", ".ts", ".tsx",  # JS/TS
+        ".java", ".go", ".rs",          # Java, Go, Rust
+        ".cpp", ".cc", ".cxx", ".hpp", ".h", ".c",  # C/C++
+        ".cs", ".php", ".rb",           # C#, PHP, Ruby
+        ".kt", ".kts", ".swift",        # Kotlin, Swift
+    ],
 }
 
 

--- a/src/parser/universal.py
+++ b/src/parser/universal.py
@@ -1,0 +1,114 @@
+"""
+Universal Regex-Based Parser.
+
+A fallback parser that uses regular expressions to extract basic
+class and function structures from unsupported languages.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+    ParseResult,
+    Visibility,
+)
+
+
+class UniversalParser(BaseParser):
+    """Regex-based parser for general programming languages."""
+
+    # We use a broad set of extensions for the UniversalParser
+    _SUPPORTED_EXTS = [
+        ".js", ".jsx", ".ts", ".tsx",  # JS/TS
+        ".java", ".go", ".rs",          # Java, Go, Rust
+        ".cpp", ".cc", ".cxx", ".hpp", ".h", ".c",  # C/C++
+        ".cs", ".php", ".rb",           # C#, PHP, Ruby
+        ".kt", ".kts", ".swift",        # Kotlin, Swift
+    ]
+
+    def __init__(self) -> None:
+        """Initialize regex patterns."""
+        # A simple pattern to catch class definitions.
+        # e.g. public class Foo, struct Bar, interface Baz
+        self._class_pattern = re.compile(
+            r'^\s*(?:public\s+|private\s+|protected\s+|export\s+|abstract\s+)*(?:class|struct|interface)\s+([A-Za-z0-9_]+)',
+            re.MULTILINE
+        )
+
+        # A simple pattern to catch function/method definitions.
+        # e.g. public static void main(, function foo(, def my_func(
+        self._func_pattern = re.compile(
+            r'^\s*(?:public\s+|private\s+|protected\s+|export\s+|static\s+|async\s+|abstract\s+|virtual\s+|override\s+)*(?:def|function|func|fn|[A-Za-z0-9_<>\[\]]+)\s+([A-Za-z0-9_]+)\s*\(',
+            re.MULTILINE
+        )
+
+    def language(self) -> str:
+        """Return the language identifier."""
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        """Return supported file extensions."""
+        return self._SUPPORTED_EXTS
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        """Parse a file using regex to find classes and functions.
+
+        Args:
+            file_path: Path to the source file.
+
+        Returns:
+            A populated ModuleInfo dataclass.
+        """
+        file_path = Path(file_path).resolve()
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            source = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Skip binary files or unreadable encodings
+            source = ""
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Extract classes
+        for match in self._class_pattern.finditer(source):
+            class_name = match.group(1)
+            # Find line number (roughly)
+            start_index = match.start()
+            line_num = source.count('\n', 0, start_index) + 1
+
+            module_info.classes.append(ClassInfo(
+                name=class_name,
+                visibility=Visibility.PUBLIC, # Default to public
+                start_line=line_num,
+                end_line=line_num,
+            ))
+
+        # Extract functions
+        for match in self._func_pattern.finditer(source):
+            func_name = match.group(1)
+
+            # Skip common keywords that might match the regex
+            if func_name in ("if", "for", "while", "switch", "catch"):
+                continue
+
+            start_index = match.start()
+            line_num = source.count('\n', 0, start_index) + 1
+
+            module_info.functions.append(FunctionInfo(
+                name=func_name,
+                visibility=Visibility.PUBLIC, # Default to public
+                start_line=line_num,
+                end_line=line_num,
+            ))
+
+        return module_info


### PR DESCRIPTION
This pull request addresses the roadmap goal to generate docs for "any language".

It introduces `UniversalParser` inside `src/parser/universal.py`. Since we cannot write full-blown AST parsers for every language in existence, this acts as a robust fallback. It uses simple multiline regular expressions to identify `class`, `interface`, `struct` definitions, as well as `function`, `def`, `fn`, and standard C-style function definitions. It maps these findings into the standard `ClassInfo` and `FunctionInfo` objects defined in `src/parser/base.py`.

In `src/cli.py`, the CLI execution path now uses the `ParserRegistry` to register both `PythonParser` and `UniversalParser`. It then combines the results of `parse_all` into a unified `ParseResult` which is then passed to the downstream analyzer and generator logic seamlessly. All related `SUPPORTED_LANGUAGES` and extensions have been updated.

---
*PR created automatically by Jules for task [13528724202509664501](https://jules.google.com/task/13528724202509664501) started by @xorinf*