### PR TITLE
feat: implement regex-based UniversalParser for multi-language support

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,10 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = [
+    "python", "js", "ts", "java", "c", "cpp", "cs", "rb", "go", "rs", "php",
+    "swift", "kt", "scala", "m", "h", "hpp"
+]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +193,27 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    # Combine results into a single ParseResult
+    parse_result = ParseResult()
+    for res in results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+
+    # We assume 'universal' or 'python' based on first module or keep it simple
+    if results:
+        parse_result.language = results[0].language
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -430,6 +451,22 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "js": [".js"],
+    "ts": [".ts"],
+    "java": [".java"],
+    "c": [".c"],
+    "cpp": [".cpp"],
+    "cs": [".cs"],
+    "rb": [".rb"],
+    "go": [".go"],
+    "rs": [".rs"],
+    "php": [".php"],
+    "swift": [".swift"],
+    "kt": [".kt"],
+    "scala": [".scala"],
+    "m": [".m"],
+    "h": [".h"],
+    "hpp": [".hpp"],
 }
 
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,80 @@
+"""
+universal_parser.py -- Fallback Parser for Multiple Languages using Regex.
+
+This module provides a UniversalParser that extracts basic class and function
+structures from non-Python languages using regular expressions. It acts as a
+fallback mechanism for languages not yet supported by dedicated AST parsers.
+"""
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+    ParseResult,
+    Visibility,
+)
+
+class UniversalParser(BaseParser):
+    """Regex-based parser for unsupported languages."""
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        # Support a broad set of common languages as fallback
+        return [
+            ".js", ".ts", ".java", ".c", ".cpp", ".cs", ".rb", ".go",
+            ".rs", ".php", ".swift", ".kt", ".scala", ".m", ".h", ".hpp"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        file_path = Path(file_path).resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        try:
+            source = file_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Fallback or skip if not decodable
+            return ModuleInfo(file_path=file_path)
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Regex for functions:
+        # Handles keyword-based (def, function, func, fn, fun) and return-type-based (C/C++/Java style)
+        func_pattern = re.compile(
+            r'(?m)^\s*(?:public\s+|private\s+|protected\s+|static\s+|async\s+|export\s+|inline\s+|virtual\s+)*'
+            r'(?:'
+                r'(?:def|function|func|fn|fun)\s+([a-zA-Z_]\w*)'  # Keyword based
+                r'|'
+                r'(?:[a-zA-Z_][\w<>\[\]]*\s+)+([a-zA-Z_]\w*)'      # Return type based
+            r')\s*\('
+        )
+        for match in func_pattern.finditer(source):
+            # match.group(1) is keyword based, match.group(2) is return type based
+            func_name = match.group(1) or match.group(2)
+            # Avoid matching control flow statements as functions in C-style languages
+            if func_name and func_name not in {"if", "for", "while", "switch", "catch"}:
+                module_info.functions.append(FunctionInfo(
+                    name=func_name,
+                    visibility=Visibility.PUBLIC, # Simplify visibility
+                ))
+
+        # Regex for classes and structs: captures class/struct name
+        class_pattern = re.compile(
+            r'(?m)^\s*(?:public\s+|private\s+|protected\s+|export\s+|abstract\s+|type\s+)*'
+            r'(?:class|struct|interface|protocol)\s+([a-zA-Z_]\w*)'
+        )
+        for match in class_pattern.finditer(source):
+            class_name = match.group(1)
+            module_info.classes.append(ClassInfo(
+                name=class_name,
+                visibility=Visibility.PUBLIC,
+            ))
+
+        return module_info


### PR DESCRIPTION
This pull request introduces a regex-based `UniversalParser` to fallback to extracting classes, functions, and structs for any language not strictly supported by a dedicated AST parser. It integrates `ParserRegistry` in `src/cli.py` and expands supported languages correctly.

---
*PR created automatically by Jules for task [5583429816467046437](https://jules.google.com/task/5583429816467046437) started by @xorinf*