### PR TITLE
feat: implement UniversalParser for any language support

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +190,23 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    # Merge ParseResult objects into one
+    parse_result = ParseResult(language="mixed")
+    for pr in parse_results:
+        parse_result.modules.extend(pr.modules)
+        parse_result.errors.extend(pr.errors)
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -430,6 +444,11 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "universal": [
+        ".js", ".jsx", ".ts", ".tsx", ".java", ".cpp", ".c", ".cc", ".cxx",
+        ".h", ".hpp", ".cs", ".go", ".rs", ".php", ".rb", ".swift", ".kt",
+        ".kts", ".scala", ".m", ".mm"
+    ]
 }
 
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,71 @@
+import re
+from pathlib import Path
+from typing import Optional
+
+from src.parser.base import BaseParser, ModuleInfo, ClassInfo, FunctionInfo, ParseResult
+
+
+class UniversalParser(BaseParser):
+    """Fallback parser that uses regex to extract structures from various languages."""
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return [
+            ".js", ".jsx", ".ts", ".tsx", ".java", ".cpp", ".c", ".cc", ".cxx",
+            ".h", ".hpp", ".cs", ".go", ".rs", ".php", ".rb", ".swift", ".kt",
+            ".kts", ".scala", ".m", ".mm"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        classes = []
+        functions = []
+
+        # Regex for classes
+        class_pattern = re.compile(r'\bclass\s+([A-Za-z_]\w*)')
+        for match in class_pattern.finditer(content):
+            class_name = match.group(1)
+            classes.append(ClassInfo(name=class_name))
+
+        # Regex for keyword-based functions
+        keyword_func_pattern = re.compile(r'\b(?:def|function|func|fn)\s+([A-Za-z_]\w*)\s*\(')
+        for match in keyword_func_pattern.finditer(content):
+            func_name = match.group(1)
+            functions.append(FunctionInfo(name=func_name))
+
+        # Regex for C-family return-type-based functions (very simplified heuristic)
+        # Matches e.g. "int main(", "void* my_func(", "MyClass::my_method("
+        # Avoid matching control structures like "if (", "for (", "while ("
+        # Must have at least one type word, followed by function name, then (
+        c_func_pattern = re.compile(r'^[ \t]*(?:(?:public|private|protected|static|virtual|inline|constexpr)\s+)*([A-Za-z_]\w*(?:<[^>]+>)?[\s\*\&]+)+([A-Za-z_]\w*)\s*\(', re.MULTILINE)
+
+        for match in c_func_pattern.finditer(content):
+            func_name = match.group(2)
+            # Filter out control flow that might accidentally match
+            if func_name not in {"if", "for", "while", "switch", "catch"}:
+                functions.append(FunctionInfo(name=func_name))
+
+        # Deduplicate functions by name to avoid double counting if regex overlap (though unlikely here)
+        unique_funcs = []
+        seen = set()
+        for f in functions:
+            if f.name not in seen:
+                seen.add(f.name)
+                unique_funcs.append(f)
+
+        unique_classes = []
+        seen_c = set()
+        for c in classes:
+            if c.name not in seen_c:
+                seen_c.add(c.name)
+                unique_classes.append(c)
+
+        return ModuleInfo(
+            file_path=file_path,
+            classes=unique_classes,
+            functions=unique_funcs
+        )


### PR DESCRIPTION
Added a `UniversalParser` to fallback to using regex for non-Python programming languages to generate basic documentation structures. Integrated this parser with the `ParserRegistry` in the CLI to allow the program to run on multi-language projects and merge the parsing results into a single output object for the semantic analyzer. Extended the configuration's supported extensions.

---
*PR created automatically by Jules for task [8998295772013531356](https://jules.google.com/task/8998295772013531356) started by @xorinf*