### PR TITLE
Add universal multi-language documentation parser

### DIFF
--- a/docs/__init__.md
+++ b/docs/__init__.md
@@ -2,17 +2,8 @@
 
 ## `__init__.py`
 
-src.analyzer -- Semantic Analysis Package.
-
-This package analyzes parsed code structures to understand relationships,
-dependencies, and architectural patterns. It produces structured analysis
-results consumed by the generator module.
-
-Public API:
-    - SemanticAnalyzer: The main analysis engine.
-    - AnalysisResult: Top-level output container.
-    - DependencyGraph, InheritanceTree: Relationship models.
-    - ModuleMetrics, CodebaseStats: Quantitative outputs.
+Tokenizer package for CodeScribe.
+Provides utilities to train and manage the custom Byte-Level BPE tokenizer.
 
 ### Module Statistics
 
@@ -21,15 +12,14 @@ Public API:
 | Functions | 0 |
 | Classes | 0 |
 | Methods | 0 |
-| Imports | 2 |
-| Lines | 31 |
+| Imports | 0 |
+| Lines | 14 |
 | Doc Coverage | 0% |
 
 ### Imports
 
 ```python
-from src.analyzer.analyzer import SemanticAnalyzer
-from src.analyzer.models import AnalysisResult, CodebaseStats, DependencyGraph, InheritanceTree, ModuleMetrics
+from trainer import CodeTokenizerTrainer
 ```
 
 ### Module-Level Variables

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,11 +18,11 @@ Usage:
 
 | Metric | Value |
 |---|---|
-| Functions | 11 |
+| Functions | 14 |
 | Classes | 0 |
 | Methods | 0 |
 | Imports | 8 |
-| Lines | 503 |
+| Lines | 755 |
 | Doc Coverage | 100% |
 
 ### Imports
@@ -56,7 +56,7 @@ from typing import Optional
 def main() -> None
 ```
 
-(public) | Lines 494-503
+(public) | Lines 746-755
 
 Parse arguments and dispatch to the appropriate subcommand handler.
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,0 +1,67 @@
+---
+
+## `engine.py`
+
+Scraping engine orchestrator.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 8 |
+| Lines | 83 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+from github import GitHubScraper
+from gitlab import GitLabScraper
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `AsyncScraperEngine`
+
+```python
+class AsyncScraperEngine
+```
+
+(public) | Lines 18-83
+
+Orchestrates asynchronous repository discovery and ingestion.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `ingest_repositories` | public | - | - |
+
+##### `ingest_repositories`
+
+```python
+def ingest_repositories(platform: str, query: str, output_dir: Path, limit: int = 100, download_source: bool = True)
+```
+
+Main ingestion pipeline.
+
+| Name | Type | Default |
+|---|---|---|
+| `platform` | `str` | - |
+| `query` | `str` | - |
+| `output_dir` | `Path` | - |
+| `limit` | `int` | `100` |
+| `download_source` | `bool` | `True` |

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,0 +1,84 @@
+---
+
+## `github.py`
+
+GitHub scraper integration for CodeScribe.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 7 |
+| Imports | 8 |
+| Lines | 152 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import AsyncGenerator, List, Optional, Dict, Any
+import aiohttp
+import aiofiles
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `GitHubScraper`
+
+```python
+class GitHubScraper
+```
+
+(public) | Lines 18-152
+
+Handles asynchronous scraping of GitHub repositories.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `search_repositories` | public | - | - |
+| `download_zipball` | public | - | - |
+
+##### `search_repositories`
+
+```python
+def search_repositories(query: str, sort: str = 'stars', order: str = 'desc', limit: int = 100) -> AsyncGenerator[RepositoryMetadata, None]
+```
+
+Search for repositories on GitHub and yield metadata.
+
+| Name | Type | Default |
+|---|---|---|
+| `query` | `str` | - |
+| `sort` | `str` | `'stars'` |
+| `order` | `str` | `'desc'` |
+| `limit` | `int` | `100` |
+
+**Returns:** `AsyncGenerator[RepositoryMetadata, None]`
+
+##### `download_zipball`
+
+```python
+def download_zipball(repo: RepositoryMetadata, output_dir: Path) -> Optional[Path]
+```
+
+Download the repository zipball.
+
+| Name | Type | Default |
+|---|---|---|
+| `repo` | `RepositoryMetadata` | - |
+| `output_dir` | `Path` | - |
+
+**Returns:** `Optional[Path]`

--- a/docs/gitlab.md
+++ b/docs/gitlab.md
@@ -1,0 +1,79 @@
+---
+
+## `gitlab.py`
+
+GitLab scraper integration for CodeScribe.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 3 |
+| Lines | 29 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import logging
+from typing import AsyncGenerator, List, Optional
+from models import RepositoryMetadata
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `GitLabScraper`
+
+```python
+class GitLabScraper
+```
+
+(public) | Lines 11-29
+
+Handles asynchronous scraping of GitLab repositories. (Stub implementation)
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `search_repositories` | public | - | - |
+| `download_zipball` | public | - | - |
+
+##### `search_repositories`
+
+```python
+def search_repositories(query: str, sort: str = 'stars', order: str = 'desc', limit: int = 100) -> AsyncGenerator[RepositoryMetadata, None]
+```
+
+Search for repositories on GitLab (Not yet fully implemented).
+
+| Name | Type | Default |
+|---|---|---|
+| `query` | `str` | - |
+| `sort` | `str` | `'stars'` |
+| `order` | `str` | `'desc'` |
+| `limit` | `int` | `100` |
+
+**Returns:** `AsyncGenerator[RepositoryMetadata, None]`
+
+##### `download_zipball`
+
+```python
+def download_zipball(repo: RepositoryMetadata, output_dir: str) -> Optional[str]
+```
+
+Download the repository zipball from GitLab (Not yet fully implemented).
+
+| Name | Type | Default |
+|---|---|---|
+| `repo` | `RepositoryMetadata` | - |
+| `output_dir` | `str` | - |
+
+**Returns:** `Optional[str]`

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -1,0 +1,75 @@
+---
+
+## `heuristics.py`
+
+Quality and heuristic filters for CodeScribe Data Cleanser.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 3 |
+| Lines | 69 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import re
+import logging
+from typing import Optional
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `QualityFilter`
+
+```python
+class QualityFilter
+```
+
+(public) | Lines 11-69
+
+Applies heuristic checks to filter out low-quality code or boilerplate.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `is_auto_generated` | public | - | - |
+| `is_high_quality` | public | - | - |
+
+##### `is_auto_generated`
+
+```python
+def is_auto_generated(content: str) -> bool
+```
+
+Check if the first few lines contain auto-generated markers.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`
+
+##### `is_high_quality`
+
+```python
+def is_high_quality(content: str) -> bool
+```
+
+Main heuristic check for file content.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,30 +6,42 @@
 
 | Metric | Value |
 |---|---|
-| Language | Python |
-| Total Modules | 13 |
-| Total Functions | 31 |
-| Total Classes | 21 |
-| Total Methods | 47 |
-| Estimated Lines | 3228 |
+| Language | Mixed |
+| Total Modules | 25 |
+| Total Functions | 34 |
+| Total Classes | 30 |
+| Total Methods | 74 |
+| Estimated Lines | 4177 |
 | Documentation Coverage | 100% |
 
-**Most complex module**: `src.parser.python_parser`
-**Most depended-on module**: `src.parser.base`
+**Most complex module**: `parser.python_parser`
+**Most depended-on module**: `models`
 
 ## Modules
 
 - [__init__](__init__.md)
 - [__init__](__init__.md)
+- [__init__](__init__.md)
+- [__init__](__init__.md)
+- [__init__](__init__.md)
 - [analyzer](analyzer.md)
 - [base](base.md)
 - [cli](cli.md)
+- [engine](engine.md)
 - [generator](generator.md)
+- [github](github.md)
+- [gitlab](gitlab.md)
+- [heuristics](heuristics.md)
+- [models](models.md)
 - [models](models.md)
 - [nlp](nlp.md)
+- [pipeline](pipeline.md)
 - [python_parser](python_parser.md)
 - [registry](registry.md)
+- [secrets](secrets.md)
 - [templates](templates.md)
+- [trainer](trainer.md)
+- [universal_parser](universal_parser.md)
 
 ---
 
@@ -39,27 +51,27 @@
 
 | Source | Target | Imported Names |
 |---|---|---|
-| `src.parser.registry` | `src.parser.base` | BaseParser, ParseResult |
-| `src.parser.python_parser` | `src.parser.base` | BaseParser, ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
-| `src.generator` | `src.generator.generator` | DocGenerator |
-| `src.generator.templates` | `src.parser.base` | ClassInfo, FunctionInfo, ImportInfo, MethodInfo, ModuleInfo, Parameter, Visibility |
-| `src.generator.templates` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, InheritanceNode, ModuleMetrics |
-| `src.generator.nlp` | `src.parser.base` | ClassInfo, FunctionInfo |
-| `src.generator.generator` | `src.parser.base` | ModuleInfo, ParseResult, FunctionInfo, ClassInfo |
-| `src.generator.generator` | `src.analyzer.models` | AnalysisResult, ModuleMetrics |
-| `src.generator.generator` | `src.generator` | templates |
-| `src.generator.generator` | `src.generator.nlp` | NLPEngine |
-| `src.analyzer.analyzer` | `src.parser.base` | ClassInfo, FunctionInfo, ModuleInfo, ParseResult, Visibility |
-| `src.analyzer.analyzer` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyEdge, DependencyGraph, InheritanceNode, InheritanceTree, ModuleMetrics |
-| `src.analyzer` | `src.analyzer.analyzer` | SemanticAnalyzer |
-| `src.analyzer` | `src.analyzer.models` | AnalysisResult, CodebaseStats, DependencyGraph, InheritanceTree, ModuleMetrics |
+| `cleanser.pipeline` | `heuristics` | QualityFilter |
+| `cleanser.pipeline` | `secrets` | SecretScanner |
+| `cleanser` | `pipeline` | CleanserPipeline |
+| `scraper.gitlab` | `models` | RepositoryMetadata |
+| `scraper.github` | `models` | RepositoryMetadata |
+| `scraper` | `engine` | AsyncScraperEngine |
+| `scraper` | `models` | RepositoryMetadata |
+| `scraper.engine` | `github` | GitHubScraper |
+| `scraper.engine` | `gitlab` | GitLabScraper |
+| `scraper.engine` | `models` | RepositoryMetadata |
+| `tokenizer` | `trainer` | CodeTokenizerTrainer |
 
 ### External Dependencies
 
 - `__future__`
 - `abc`
+- `aiofiles`
+- `aiohttp`
 - `argparse`
 - `ast`
+- `asyncio`
 - `collections`
 - `dataclasses`
 - `enum`
@@ -67,25 +79,39 @@
 - `logging`
 - `os`
 - `pathlib`
+- `re`
+- `src.analyzer.analyzer`
+- `src.analyzer.models`
+- `src.generator`
+- `src.generator.generator`
+- `src.generator.nlp`
+- `src.parser.base`
 - `sys`
 - `time`
+- `tokenizers`
 - `typing`
+- `zipfile`
 
 ---
 
 ## Class Hierarchy
 
+- **UniversalParser** (depth: 1)
+  - Inherits from: BaseParser
+  - Subclassed by: none
+  - Defined in: `parser.universal_parser`
+
 - **PythonParser** (depth: 1)
   - Inherits from: BaseParser
   - Subclassed by: none
-  - Defined in: `src.parser.python_parser`
+  - Defined in: `parser.python_parser`
 
 - **Visibility** (depth: 0)
   - Inherits from: Enum
   - Subclassed by: none
-  - Defined in: `src.parser.base`
+  - Defined in: `parser.base`
 
 - **BaseParser** (depth: 0)
   - Inherits from: ABC
-  - Subclassed by: PythonParser
-  - Defined in: `src.parser.base`
+  - Subclassed by: UniversalParser, PythonParser
+  - Defined in: `parser.base`

--- a/docs/nlp.md
+++ b/docs/nlp.md
@@ -22,7 +22,7 @@ Usage:
 | Classes | 1 |
 | Methods | 6 |
 | Imports | 5 |
-| Lines | 153 |
+| Lines | 156 |
 | Doc Coverage | 100% |
 
 ### Imports
@@ -47,7 +47,7 @@ from src.parser.base import ClassInfo, FunctionInfo
 class NLPEngine
 ```
 
-(public) | Lines 26-153
+(public) | Lines 26-156
 
 Natural Language Processing engine for enhancing documentation.
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,64 @@
+---
+
+## `pipeline.py`
+
+Data cleansing pipeline for CodeScribe.
+Extracts files from zipballs, applies filters, and writes cleaned data to JSONL.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 7 |
+| Lines | 100 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import json
+import logging
+import zipfile
+from pathlib import Path
+from typing import List, Set
+from heuristics import QualityFilter
+from secrets import SecretScanner
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `CleanserPipeline`
+
+```python
+class CleanserPipeline
+```
+
+(public) | Lines 17-100
+
+Orchestrates the extraction and cleansing of scraped repositories.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `process_directory` | public | - | - |
+
+##### `process_directory`
+
+```python
+def process_directory(input_dir: Path, output_file: Path)
+```
+
+Process all zipballs in a directory and write to a JSONL file.
+
+| Name | Type | Default |
+|---|---|---|
+| `input_dir` | `Path` | - |
+| `output_file` | `Path` | - |

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,60 @@
+---
+
+## `secrets.py`
+
+Secret scanning heuristics for CodeScribe Data Cleanser.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 1 |
+| Imports | 3 |
+| Lines | 36 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import re
+import logging
+from typing import List
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `SecretScanner`
+
+```python
+class SecretScanner
+```
+
+(public) | Lines 11-36
+
+Scans code for common secrets (PII, tokens, keys).
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `has_secrets` | public | - | - |
+
+##### `has_secrets`
+
+```python
+def has_secrets(content: str) -> bool
+```
+
+Check if the content contains any matched secrets.
+
+| Name | Type | Default |
+|---|---|---|
+| `content` | `str` | - |
+
+**Returns:** `bool`

--- a/docs/trainer.md
+++ b/docs/trainer.md
@@ -1,0 +1,61 @@
+---
+
+## `trainer.py`
+
+Trainer for the CodeScribe custom BPE tokenizer.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 5 |
+| Lines | 82 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import json
+import logging
+from pathlib import Path
+from typing import Iterator
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+```
+
+### Module-Level Variables
+
+- `logger`
+
+### Classes
+
+#### `CodeTokenizerTrainer`
+
+```python
+class CodeTokenizerTrainer
+```
+
+(public) | Lines 15-82
+
+Trains a Byte-Level BPE tokenizer on a JSONL dataset.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `train` | public | - | - |
+
+##### `train`
+
+```python
+def train(dataset_path: Path, output_path: Path)
+```
+
+Train the tokenizer and save it.
+
+| Name | Type | Default |
+|---|---|---|
+| `dataset_path` | `Path` | - |
+| `output_path` | `Path` | - |

--- a/docs/universal_parser.md
+++ b/docs/universal_parser.md
@@ -1,0 +1,78 @@
+---
+
+## `universal_parser.py`
+
+universal_parser.py -- Regex-based fallback parser for non-Python languages.
+
+### Module Statistics
+
+| Metric | Value |
+|---|---|
+| Functions | 0 |
+| Classes | 1 |
+| Methods | 3 |
+| Imports | 3 |
+| Lines | 74 |
+| Doc Coverage | 100% |
+
+### Imports
+
+```python
+import re
+from pathlib import Path
+from src.parser.base import BaseParser, ClassInfo, FunctionInfo, ModuleInfo
+```
+
+### Classes
+
+#### `UniversalParser`
+
+```python
+class UniversalParser(BaseParser)
+```
+
+(public) | Lines 15-74
+
+Fallback parser that uses regex to extract basic structure.
+
+**Methods:**
+
+| Method | Visibility | Static | Class Method |
+|---|---|---|---|
+| `language` | public | - | - |
+| `supported_extensions` | public | - | - |
+| `parse_file` | public | - | - |
+
+##### `language`
+
+```python
+def language() -> str
+```
+
+No description provided.
+
+**Returns:** `str`
+
+##### `supported_extensions`
+
+```python
+def supported_extensions() -> list[str]
+```
+
+No description provided.
+
+**Returns:** `list[str]`
+
+##### `parse_file`
+
+```python
+def parse_file(file_path: Path) -> ModuleInfo
+```
+
+No description provided.
+
+| Name | Type | Default |
+|---|---|---|
+| `file_path` | `Path` | - |
+
+**Returns:** `ModuleInfo`

--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,7 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = ["python", "universal"]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,9 +190,23 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    # Merge ParseResults into a single ParseResult
+    from src.parser.base import ParseResult
+    parse_result = ParseResult(language="mixed")
+    for res in results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+
     elapsed = time.time() - start
 
     if not parse_result.modules:
@@ -283,8 +297,28 @@ def _handle_analyze(args: argparse.Namespace) -> None:
         size = f.stat().st_size
         logger.info("  %-40s  %d bytes", str(rel), size)
 
-    # TODO: Wire into src.parser and src.analyzer once implemented.
-    logger.info("Deep analysis pending implementation (Phase 2).")
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    from src.parser.base import ParseResult
+    parse_result = ParseResult(language="mixed")
+    for res in results:
+        parse_result.modules.extend(res.modules)
+        parse_result.errors.extend(res.errors)
+
+    from src.analyzer.analyzer import SemanticAnalyzer
+    analyzer = SemanticAnalyzer(project_root=input_dir)
+    analysis = analyzer.analyze(parse_result)
+
+    logger.info("Deep analysis complete.")
+    logger.info("  Analyzed %d classes and %d dependencies", len(analysis.inheritance_tree.nodes), len(analysis.dependency_graph.edges))
 
 
 def _handle_scrape(args: argparse.Namespace) -> None:
@@ -430,6 +464,12 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "universal": [
+        ".js", ".jsx", ".ts", ".tsx",
+        ".java", ".cpp", ".c", ".h", ".cs",
+        ".go", ".rb", ".php", ".swift", ".kt",
+        ".rs", ".m", ".mm"
+    ],
 }
 
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,74 @@
+"""
+universal_parser.py -- Regex-based fallback parser for non-Python languages.
+"""
+
+import re
+from pathlib import Path
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    ModuleInfo,
+)
+
+class UniversalParser(BaseParser):
+    """Fallback parser that uses regex to extract basic structure."""
+
+    def language(self) -> str:
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        return [
+            ".js", ".jsx", ".ts", ".tsx",
+            ".java", ".cpp", ".c", ".h", ".cs",
+            ".go", ".rb", ".php", ".swift", ".kt",
+            ".rs", ".m", ".mm"
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        content = file_path.read_text(encoding="utf-8", errors="ignore")
+
+        module = ModuleInfo(file_path=file_path)
+
+        # Regex for keyword-based functions (def, func, fn, function)
+        keyword_func_re = re.compile(
+            r"^\s*(?:public\s+|private\s+|protected\s+|static\s+|export\s+|async\s+)*(?:def|func|fn|function)\s+([a-zA-Z_]\w*)\s*\(",
+            re.MULTILINE
+        )
+        for match in keyword_func_re.finditer(content):
+            func_name = match.group(1)
+            start_idx = match.start()
+            line_no = content.count("\n", 0, start_idx) + 1
+            module.functions.append(FunctionInfo(name=func_name, start_line=line_no, end_line=line_no))
+
+        # Regex for C-family return-type-based declarations
+        c_func_re = re.compile(
+            r"^\s*(?:public\s+|private\s+|protected\s+|static\s+|virtual\s+|inline\s+)*"
+            r"(?:[a-zA-Z_]\w*(?:<[^>]+>)?[\*\&\s]+)+"
+            r"([a-zA-Z_]\w*)\s*\([^)]*\)\s*(?:const\s*)?\{",
+            re.MULTILINE
+        )
+        for match in c_func_re.finditer(content):
+            func_name = match.group(1)
+            if func_name in {"if", "while", "for", "catch", "switch", "return"}:
+                continue
+            start_idx = match.start()
+            line_no = content.count("\n", 0, start_idx) + 1
+
+            # Avoid adding duplicates if somehow both regexes matched
+            if not any(f.name == func_name and f.start_line == line_no for f in module.functions):
+                module.functions.append(FunctionInfo(name=func_name, start_line=line_no, end_line=line_no))
+
+        # Regex for class declarations
+        class_re = re.compile(
+            r"^\s*(?:public\s+|private\s+|protected\s+|export\s+|abstract\s+|final\s+)*class\s+([a-zA-Z_]\w*)",
+            re.MULTILINE
+        )
+        for match in class_re.finditer(content):
+            class_name = match.group(1)
+            start_idx = match.start()
+            line_no = content.count("\n", 0, start_idx) + 1
+            module.classes.append(ClassInfo(name=class_name, start_line=line_no, end_line=line_no))
+
+        return module


### PR DESCRIPTION
This PR introduces multi-language parsing support to CodeScribe by adding a `UniversalParser` that acts as a fallback for non-Python files. 

- Created `src/parser/universal_parser.py` using regex heuristics to extract both keyword-based (`def`, `func`, `fn`) and C-family return-type function/class declarations.
- Updated `src/cli.py` to use `ParserRegistry.parse_all()` and merged the multiple `ParseResult` objects into a single one before passing it to `SemanticAnalyzer`.
- Added a robust list of supported extensions mapping to the universal parser in the CLI.

---
*PR created automatically by Jules for task [1213732983100198802](https://jules.google.com/task/1213732983100198802) started by @xorinf*