### PR TITLE
feat: add universal parser to support multi-language documentation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,24 @@ APP_NAME: str = "CodeScribe"
 APP_VERSION: str = "0.1.0"
 DEFAULT_CONFIG_FILENAME: str = "codescribe.json"
 DEFAULT_OUTPUT_DIR: str = "./docs"
-SUPPORTED_LANGUAGES: list[str] = ["python"]
+SUPPORTED_LANGUAGES: list[str] = [
+    "python",
+    "javascript",
+    "typescript",
+    "java",
+    "c",
+    "cpp",
+    "csharp",
+    "go",
+    "rust",
+    "ruby",
+    "php",
+    "swift",
+    "kotlin",
+    "objective-c",
+    "scala",
+    "groovy",
+]
 
 # Default configuration values written by `codescribe init`
 DEFAULT_CONFIG: dict = {
@@ -190,21 +207,36 @@ def _handle_generate(args: argparse.Namespace) -> None:
     logger.info("Step 1/3 -- Parsing source files...")
     start = time.time()
     
+    from src.parser.registry import ParserRegistry
     from src.parser.python_parser import PythonParser
-    parser = PythonParser()
-    parse_result = parser.parse_directory(input_dir, exclude_dirs=config.get("exclude", []))
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
     elapsed = time.time() - start
 
-    if not parse_result.modules:
+    # Combine all parse results into one
+    combined_result = ParseResult(language="mixed")
+    for pr in parse_results:
+        combined_result.modules.extend(pr.modules)
+        combined_result.errors.extend(pr.errors)
+
+    if not combined_result.modules:
         logger.warning("No supported source files found in %s", input_dir)
         logger.warning("Supported languages: %s", ", ".join(SUPPORTED_LANGUAGES))
         sys.exit(0)
 
     logger.info(
         "  Parsed %d module(s) in %.2fs",
-        len(parse_result.modules),
+        len(combined_result.modules),
         elapsed,
     )
+
+    parse_result = combined_result
 
     # ------------------------------------------------------------------
     # Step 2: Analyze code structure
@@ -283,8 +315,37 @@ def _handle_analyze(args: argparse.Namespace) -> None:
         size = f.stat().st_size
         logger.info("  %-40s  %d bytes", str(rel), size)
 
-    # TODO: Wire into src.parser and src.analyzer once implemented.
-    logger.info("Deep analysis pending implementation (Phase 2).")
+    from src.parser.registry import ParserRegistry
+    from src.parser.python_parser import PythonParser
+    from src.parser.universal_parser import UniversalParser
+    from src.parser.base import ParseResult
+
+    registry = ParserRegistry()
+    registry.register(PythonParser())
+    registry.register(UniversalParser())
+
+    parse_results = registry.parse_all(input_dir, exclude_dirs=config.get("exclude", []))
+
+    combined_result = ParseResult(language="mixed")
+    for pr in parse_results:
+        combined_result.modules.extend(pr.modules)
+        combined_result.errors.extend(pr.errors)
+
+    if not combined_result.modules:
+        logger.warning("No parseable structures found in %s", input_dir)
+        sys.exit(0)
+
+    logger.info("Parsed %d modules.", len(combined_result.modules))
+
+    from src.analyzer.analyzer import SemanticAnalyzer
+    analyzer = SemanticAnalyzer(project_root=input_dir)
+    analysis = analyzer.analyze(combined_result)
+
+    logger.info(
+        "Analyzed %d classes and %d dependencies.",
+        len(analysis.inheritance_tree.nodes),
+        len(analysis.dependency_graph.edges),
+    )
 
 
 def _handle_scrape(args: argparse.Namespace) -> None:
@@ -430,6 +491,21 @@ def _handle_version(args: argparse.Namespace) -> None:
 # Map of supported language names to their file extensions.
 _LANGUAGE_EXTENSIONS: dict[str, list[str]] = {
     "python": [".py"],
+    "javascript": [".js", ".jsx"],
+    "typescript": [".ts", ".tsx"],
+    "java": [".java"],
+    "c": [".c", ".h"],
+    "cpp": [".cpp", ".hpp", ".cc", ".hh"],
+    "csharp": [".cs"],
+    "go": [".go"],
+    "rust": [".rs"],
+    "ruby": [".rb"],
+    "php": [".php"],
+    "swift": [".swift"],
+    "kotlin": [".kt", ".kts"],
+    "objective-c": [".m", ".mm"],
+    "scala": [".scala"],
+    "groovy": [".groovy"],
 }
 
 

--- a/src/parser/universal_parser.py
+++ b/src/parser/universal_parser.py
@@ -1,0 +1,163 @@
+"""
+universal_parser.py -- Regex-based Universal Parser for Non-Python Languages.
+
+Acts as a fallback to extract basic class and function structures from
+non-Python languages using regular expressions. Handles both keyword-based
+and C-family return-type-based declarations.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from src.parser.base import (
+    BaseParser,
+    ClassInfo,
+    FunctionInfo,
+    MethodInfo,
+    ModuleInfo,
+    Visibility,
+)
+
+
+class UniversalParser(BaseParser):
+    """Regex-based parser for non-Python languages."""
+
+    def language(self) -> str:
+        """Return the language identifier."""
+        return "universal"
+
+    def supported_extensions(self) -> list[str]:
+        """Return supported file extensions for the universal parser."""
+        return [
+            ".js", ".ts", ".jsx", ".tsx",  # JavaScript / TypeScript
+            ".java",                        # Java
+            ".c", ".h",                     # C
+            ".cpp", ".hpp", ".cc", ".hh",   # C++
+            ".cs",                          # C#
+            ".go",                          # Go
+            ".rs",                          # Rust
+            ".rb",                          # Ruby
+            ".php",                         # PHP
+            ".swift",                       # Swift
+            ".kt", ".kts",                  # Kotlin
+            ".m", ".mm",                    # Objective-C / Objective-C++
+            ".scala",                       # Scala
+            ".groovy",                      # Groovy
+        ]
+
+    def parse_file(self, file_path: Path) -> ModuleInfo:
+        """Parse a source file using regular expressions.
+
+        Args:
+            file_path: Path to the source file.
+
+        Returns:
+            A populated ModuleInfo dataclass.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+        file_path = Path(file_path).resolve()
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+        lines = source.splitlines()
+
+        module_info = ModuleInfo(file_path=file_path)
+
+        # Basic regex for classes, structs, interfaces
+        # e.g., class Foo { ... }
+        #       struct Bar { ... }
+        #       interface Baz { ... }
+        class_pattern = re.compile(
+            r'^\s*(?:public\s+|private\s+|protected\s+|internal\s+)?(?:abstract\s+|sealed\s+|final\s+)?(class|struct|interface|trait)\s+([a-zA-Z_]\w*)(?:\s*(?:extends|implements|:)\s*([a-zA-Z0-9_<>, \t]+))?\s*\{?',
+            re.MULTILINE
+        )
+
+        # Regex for keyword-based functions (def, func, fn, function)
+        # e.g., function doSomething(arg) { ... }
+        #       def do_something(arg)
+        #       func doSomething(arg string) error { ... }
+        #       fn do_something(arg: &str) -> Result<(), Error> { ... }
+        kw_func_pattern = re.compile(
+            r'^\s*(?:public\s+|private\s+|protected\s+|internal\s+|static\s+|async\s+|export\s+)*\b(def|func|fn|function)\b\s+([a-zA-Z_]\w*)\s*\(([^)]*)\)',
+            re.MULTILINE
+        )
+
+        # Regex for C-family functions (return type followed by name)
+        # e.g., int main(int argc, char** argv)
+        #       void doSomething() { ... }
+        #       std::string get_name() const;
+        # Excludes known keywords to avoid false positives
+        c_func_pattern = re.compile(
+            r'^\s*(?:public\s+|private\s+|protected\s+|internal\s+|static\s+|virtual\s+|inline\s+|constexpr\s+)*([a-zA-Z_][\w:<>]*[\s\*&]+)([a-zA-Z_]\w*)\s*\(([^)]*)\)',
+            re.MULTILINE
+        )
+
+        # Extract classes
+        for match in class_pattern.finditer(source):
+            kind = match.group(1)
+            name = match.group(2)
+            # Find line number (inefficient but works for a basic parser)
+            start_index = match.start()
+            line_no = source[:start_index].count("\n") + 1
+
+            # Simple visibility heuristic based on name
+            visibility = Visibility.PRIVATE if name.startswith("_") else Visibility.PUBLIC
+
+            class_info = ClassInfo(
+                name=name,
+                visibility=visibility,
+                start_line=line_no,
+                end_line=line_no,  # Hard to accurately determine without a real parser
+            )
+            module_info.classes.append(class_info)
+
+        # Extract keyword-based functions
+        for match in kw_func_pattern.finditer(source):
+            kw = match.group(1)
+            name = match.group(2)
+
+            start_index = match.start()
+            line_no = source[:start_index].count("\n") + 1
+
+            visibility = Visibility.PRIVATE if name.startswith("_") else Visibility.PUBLIC
+
+            func_info = FunctionInfo(
+                name=name,
+                visibility=visibility,
+                start_line=line_no,
+                end_line=line_no,
+            )
+            module_info.functions.append(func_info)
+
+        # Extract C-family functions
+        for match in c_func_pattern.finditer(source):
+            return_type = match.group(1).strip()
+            name = match.group(2)
+
+            # Skip if it looks like a control flow keyword
+            if name in {"if", "for", "while", "switch", "catch", "return"}:
+                continue
+            if return_type in {"return", "new", "delete", "throw", "else"}:
+                continue
+
+            start_index = match.start()
+            line_no = source[:start_index].count("\n") + 1
+
+            visibility = Visibility.PRIVATE if name.startswith("_") else Visibility.PUBLIC
+
+            func_info = FunctionInfo(
+                name=name,
+                return_type=return_type,
+                visibility=visibility,
+                start_line=line_no,
+                end_line=line_no,
+            )
+            module_info.functions.append(func_info)
+
+        return module_info


### PR DESCRIPTION
Implements a Regex-based UniversalParser to support documentation generation for multiple programming languages. Updates the CLI to use `ParserRegistry` properly, executing `PythonParser` and `UniversalParser` simultaneously and combining their `ParseResult` before analyzing the AST structures.

---
*PR created automatically by Jules for task [1449148901505198629](https://jules.google.com/task/1449148901505198629) started by @xorinf*